### PR TITLE
Enhanced CSS for Interactive Code Block Features

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.scss
+++ b/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.scss
@@ -124,8 +124,7 @@
           background: #F3F6FA;
           border-color: #305680;
           padding-right: 38px;
-          overflow: scroll;
-          padding-bottom: 4px;
+          overflow: auto;
           min-height: 42px;
           scrollbar-width: thin;
 
@@ -137,28 +136,8 @@
       }
       button.clipboard-btn {
         right: -2px;
-        p {
-          color: #305680;
-        }
         p, div {
           background-color: #F3F6FA;
-        }
-        div {
-          img {
-            display: none;
-          }
-          &:after {
-            content: "";
-            position: initial;
-            display: block;
-            width: 18px;
-            height: 18px;
-            background: #305680;
-            mask-image: url(/assets/copy-code-icon.svg);
-            -webkit-mask-image: url(/assets/copy-code-icon.svg);
-            mask-repeat: no-repeat;
-            -webkit-mask-repeat: no-repeat;
-          }
         }
       }
     }

--- a/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.ts
@@ -138,7 +138,7 @@ export class DeviceCheckConnectivityDialogComponent extends
   private createMarkDownSingleCommand(command: string): string {
     return '```bash\n' +
       command +
-      '{:copy-code}\n' +
+      '{:copy-code.small}\n' +
       '```';
   }
 

--- a/ui-ngx/src/app/modules/home/pages/edge/edge-instructions-dialog.component.scss
+++ b/ui-ngx/src/app/modules/home/pages/edge/edge-instructions-dialog.component.scss
@@ -97,9 +97,6 @@
             -webkit-mask-repeat: no-repeat;
           }
         }
-        &.multiline {
-          right: -2px !important;
-        }
       }
     }
     & > *:not(ul) {

--- a/ui-ngx/src/app/shared/components/markdown.component.scss
+++ b/ui-ngx/src/app/shared/components/markdown.component.scss
@@ -280,10 +280,6 @@
         -ms-user-select: none;
         user-select: none;
 
-        &.multiline {
-          right: 44px;
-        }
-
         p {
           padding: 8px;
           top: 1px;
@@ -311,6 +307,20 @@
             width: 18px;
             height: 18px;
             filter: invert(51%) sepia(6%) saturate(172%) hue-rotate(177deg) brightness(94%) contrast(92%);
+          }
+        }
+
+        &.small {
+          height: 32px;
+          p {
+            top: 9px;
+            padding: 1px 8px;
+          }
+          div {
+            width: 36px;
+            height: 32px;
+            top: 4px;
+            padding-bottom: 2px;
           }
         }
       }


### PR DESCRIPTION
### Enhanced CSS for Interactive Code Block Features
**Description:**
- Student
  - Name: Eng Jun Cheng
  - Matric No: U2102780

- Addressed Issue 
  - Had resolves the styling inconsistencies for code block buttons across multiple pages within the application and make sure user will have a uniform and seamless user experience when intended to copy any code.

- What Has Been Reengineered
  - Had try to centralized CSS in the application by moving the common styles for code block elements into a shared base style file.
  - Had also make sure that the scrollbar does not overlap each other with using the class designed to handle code block elements that overlap vertical scrollbars.
  - Had removed page-specific classes for code block buttons in multiline components to align with the centralized approach.

- Reengineering Strategy or Approach Used
  - Rework strategy:
    - Had reorganized the CSS to remove the redundant styles using multiple pages and implement improvements to handle scrollbars better without discarding the entire styling ways.
  - Incremental approach:
    - The changes were made incrementally allow the progressive updates through multiple version when locate the error then make the changes and update incrementally. In this pr, error is located like scrollbar overlapping issue and then implement the new  CSS class that resolves overlapping issues with scrollbars

- Impact of Changes
  - Had also try to restructure the project to reduced code redundancy and improved overall maintainability by centralizing styles.
  - Had also work on the code block for a consistent look and behavior across all relevant pages.
    - Before:
       ![image](https://github.com/user-attachments/assets/dec95835-81b8-4a7c-882e-e5da54ec7584)
    - After:
        ![image](https://github.com/user-attachments/assets/8dee0efd-b854-48f3-9e0e-6568a52d2633)
  - Had Improved interaction with code block elements for the scrollable code blocks
    - before: 
       ![image](https://github.com/user-attachments/assets/509293f5-15f5-4f1d-aa94-e298f999a0c8)
    - After:
        ![image](https://github.com/user-attachments/assets/3266e2fc-9f4e-4ff7-9274-a3fd575d9430)