### PR TITLE
Updated annotations in AlarmController as per standard of spring-boot

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/AlarmController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/AlarmController.java
@@ -24,6 +24,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -104,8 +107,7 @@ public class AlarmController extends BaseController {
     @ApiOperation(value = "Get Alarm (getAlarmById)",
             notes = "Fetch the Alarm object based on the provided Alarm Id. " + ALARM_SECURITY_CHECK)
     @PreAuthorize("hasAnyAuthority('TENANT_ADMIN', 'CUSTOMER_USER')")
-    @RequestMapping(value = "/alarm/{alarmId}", method = RequestMethod.GET)
-    @ResponseBody
+    @GetMapping(value="/alarm/{alarmId}")
     public Alarm getAlarmById(@Parameter(description = ALARM_ID_PARAM_DESCRIPTION)
                               @PathVariable(ALARM_ID) String strAlarmId) throws ThingsboardException {
         checkParameter(ALARM_ID, strAlarmId);
@@ -117,8 +119,7 @@ public class AlarmController extends BaseController {
             notes = "Fetch the Alarm Info object based on the provided Alarm Id. " +
                     ALARM_SECURITY_CHECK + ALARM_INFO_DESCRIPTION + TENANT_OR_CUSTOMER_AUTHORITY_PARAGRAPH)
     @PreAuthorize("hasAnyAuthority('TENANT_ADMIN', 'CUSTOMER_USER')")
-    @RequestMapping(value = "/alarm/info/{alarmId}", method = RequestMethod.GET)
-    @ResponseBody
+    @GetMapping(value = "/alarm/info/{alarmId}")
     public AlarmInfo getAlarmInfoById(@Parameter(description = ALARM_ID_PARAM_DESCRIPTION)
                                       @PathVariable(ALARM_ID) String strAlarmId) throws ThingsboardException {
         checkParameter(ALARM_ID, strAlarmId);
@@ -139,8 +140,7 @@ public class AlarmController extends BaseController {
                     TENANT_OR_CUSTOMER_AUTHORITY_PARAGRAPH
             )
     @PreAuthorize("hasAnyAuthority('TENANT_ADMIN', 'CUSTOMER_USER')")
-    @RequestMapping(value = "/alarm", method = RequestMethod.POST)
-    @ResponseBody
+    @PostMapping(value = "/alarm")
     public Alarm saveAlarm(@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "A JSON value representing the alarm.") @RequestBody Alarm alarm) throws ThingsboardException {
         alarm.setTenantId(getTenantId());
         checkNotNull(alarm.getOriginator());
@@ -155,8 +155,7 @@ public class AlarmController extends BaseController {
     @ApiOperation(value = "Delete Alarm (deleteAlarm)",
             notes = "Deletes the Alarm. Referencing non-existing Alarm Id will cause an error." + TENANT_OR_CUSTOMER_AUTHORITY_PARAGRAPH)
     @PreAuthorize("hasAnyAuthority('TENANT_ADMIN', 'CUSTOMER_USER')")
-    @RequestMapping(value = "/alarm/{alarmId}", method = RequestMethod.DELETE)
-    @ResponseBody
+    @DeleteMapping(value = "/alarm/{alarmId}")
     public Boolean deleteAlarm(@Parameter(description = ALARM_ID_PARAM_DESCRIPTION) @PathVariable(ALARM_ID) String strAlarmId) throws ThingsboardException {
         checkParameter(ALARM_ID, strAlarmId);
         AlarmId alarmId = new AlarmId(toUUID(strAlarmId));
@@ -169,7 +168,7 @@ public class AlarmController extends BaseController {
                     "Once acknowledged, the 'ack_ts' field will be set to current timestamp and special rule chain event 'ALARM_ACK' will be generated. " +
                     "Referencing non-existing Alarm Id will cause an error." + TENANT_OR_CUSTOMER_AUTHORITY_PARAGRAPH)
     @PreAuthorize("hasAnyAuthority('TENANT_ADMIN', 'CUSTOMER_USER')")
-    @RequestMapping(value = "/alarm/{alarmId}/ack", method = RequestMethod.POST)
+    @PostMapping(value = "/alarm/{alarmId}/ack")
     @ResponseStatus(value = HttpStatus.OK)
     public AlarmInfo ackAlarm(@Parameter(description = ALARM_ID_PARAM_DESCRIPTION) @PathVariable(ALARM_ID) String strAlarmId) throws Exception {
         checkParameter(ALARM_ID, strAlarmId);
@@ -184,7 +183,7 @@ public class AlarmController extends BaseController {
                     "Once cleared, the 'clear_ts' field will be set to current timestamp and special rule chain event 'ALARM_CLEAR' will be generated. " +
                     "Referencing non-existing Alarm Id will cause an error." + TENANT_OR_CUSTOMER_AUTHORITY_PARAGRAPH)
     @PreAuthorize("hasAnyAuthority('TENANT_ADMIN', 'CUSTOMER_USER')")
-    @RequestMapping(value = "/alarm/{alarmId}/clear", method = RequestMethod.POST)
+    @PostMapping(value = "/alarm/{alarmId}/clear")
     @ResponseStatus(value = HttpStatus.OK)
     public AlarmInfo clearAlarm(@Parameter(description = ALARM_ID_PARAM_DESCRIPTION) @PathVariable(ALARM_ID) String strAlarmId) throws Exception {
         checkParameter(ALARM_ID, strAlarmId);
@@ -236,8 +235,7 @@ public class AlarmController extends BaseController {
             notes = "Returns a page of alarms for the selected entity. Specifying both parameters 'searchStatus' and 'status' at the same time will cause an error. " +
                     PAGE_DATA_PARAMETERS + TENANT_OR_CUSTOMER_AUTHORITY_PARAGRAPH)
     @PreAuthorize("hasAnyAuthority('SYS_ADMIN', 'TENANT_ADMIN', 'CUSTOMER_USER')")
-    @RequestMapping(value = "/alarm/{entityType}/{entityId}", method = RequestMethod.GET)
-    @ResponseBody
+    @GetMapping(value = "/alarm/{entityType}/{entityId}")
     public PageData<AlarmInfo> getAlarms(
             @Parameter(description = ENTITY_TYPE_PARAM_DESCRIPTION, required = true, schema = @Schema(defaultValue = "DEVICE"))
             @PathVariable(ENTITY_TYPE) String strEntityType,
@@ -468,8 +466,7 @@ public class AlarmController extends BaseController {
                     "Specifying both parameters 'searchStatus' and 'status' at the same time will cause an error." + TENANT_OR_CUSTOMER_AUTHORITY_PARAGRAPH
             )
     @PreAuthorize("hasAnyAuthority('TENANT_ADMIN', 'CUSTOMER_USER')")
-    @RequestMapping(value = "/alarm/highestSeverity/{entityType}/{entityId}", method = RequestMethod.GET)
-    @ResponseBody
+    @GetMapping(value = "/alarm/highestSeverity/{entityType}/{entityId}")
     public AlarmSeverity getHighestAlarmSeverity(
             @Parameter(description = ENTITY_TYPE_PARAM_DESCRIPTION, required = true, schema = @Schema(defaultValue = "DEVICE"))
             @PathVariable(ENTITY_TYPE) String strEntityType,


### PR DESCRIPTION
Description
Student
Name: Chong Jia Xuan
Matric No: U2102725

The addressed issue
I addressed the issue of verbosity and redundancy. The change improves the readability and maintainability of the code, adhering to modern Spring Boot practices. This transition also ensures that the code aligns with best practices.

What you have reengineered
 Removed @RequestMapping and @ResponseBody which are redundant because @GetMapping inherently specifies the HTTP method (GET) and, in the context of @RestController, automatically adds the @ResponseBody behavior, this concise annotation simplifies the code, improving readability and clarity by explicitly indicating the method handles GET requests. 

Reengineering strategy or approach used 
Incremental approach, changes were introduced gradually by modifying the annotations one by one by adding the annotation one by one to the api. This allowed for testing and validation of functionality without disrupting the current system.

Impact of changes
The @GetMapping (or @PutMapping, PostMapping) annotation is specifically designed for handling HTTP GET requests, and by default, it treats the return value as the response body. The change results in cleaner code that's easier to maintain in the long term. With @GetMapping (or @PutMapping, PostMapping), developers immediately understand the method's role in handling HTTP GET requests without needing to inspect additional annotations or attributes. This led to a more streamlined and modern approach to defining RESTful APIs in Spring, making the codebase easier to work with.

Call graph
![Blank diagram (2)](https://github.com/user-attachments/assets/2cb3696b-33ea-4dde-a00c-f39ba0bcb102)

The graph illustrates how changing from @RequestMapping to @GetMapping in ThingsBoard's controllers affects the system flow. It shows requests originating from clients (UI/HTTP clients) flowing through the API Gateway to reach the modified controllers (Alarm). The annotation changes impact multiple areas: Spring request handlers, API documentation (Swagger), security filters.

The impact or insights gained from the analysis

The modification to GET-only endpoints necessitates thorough testing across multiple layers. Integration tests must be updated to ensure they properly validate the restricted HTTP methods. Documentation requires significant updates across various levels. API specifications must reflect the new endpoint restrictions, client documentation needs revision to accurately represent the available methods, and SDK documentation should be updated to reflect the modified interaction patterns. From a security perspective, the stricter HTTP method restrictions enhance endpoint protection by limiting operations to GET requests only. This requires validation of security filters and verification of authentication flows to ensure they align with the new constraints. Client-side components face substantial impact, requiring UI testing to verify compatibility with GET-only endpoints. 

@GetMapping is more intuitive and descriptive as it explicitly specifies the HTTP method (GET) in the annotation. This improves the readability of the code for developers, making it clear what type of request the endpoint supports. Since @GetMapping is specific to HTTP GET requests, it reduces the chances of misconfiguring an endpoint with multiple HTTP methods, thereby simplifying debugging and maintenance.




